### PR TITLE
Add option to skip dispatching duplicate event on backend transition

### DIFF
--- a/packages/dnd-multi-backend/src/MultiBackend.js
+++ b/packages/dnd-multi-backend/src/MultiBackend.js
@@ -53,6 +53,7 @@ export default class {
         instance: new backend.backend(manager),
         preview: (backend.preview || false),
         transition,
+        skipDispatchOnTransition: Boolean(backend.skipDispatchOnTransition),
       });
     });
 
@@ -137,7 +138,13 @@ export default class {
         node.handler = this.callBackend(node.func, node.args);
       });
       PreviewManager.backendChanged(this);
-      this.backends[this.current].instance.setup();
+
+      const newBackend = this.backends[this.current];
+      newBackend.instance.setup();
+
+      if (newBackend.skipDispatchOnTransition) {
+        return;
+      }
 
       let newEvent = null;
       try {

--- a/packages/dnd-multi-backend/src/__tests__/MultiBackend_spec.js
+++ b/packages/dnd-multi-backend/src/__tests__/MultiBackend_spec.js
@@ -39,7 +39,7 @@ describe('PreviewList class', () => {
 
 describe('MultiBackend class', () => {
   let _defaultPipeline;
-  let _defaultPipelineWithSkipDispatch;
+  let _pipelineWithSkipDispatch;
 
   beforeEach(() => {
     const newBackend = () => {
@@ -60,7 +60,7 @@ describe('MultiBackend class', () => {
       {backend: backend1ctr},
       {backend: backend2ctr, preview: true, transition},
     ]};
-    _defaultPipelineWithSkipDispatch = {backends: [
+    _pipelineWithSkipDispatch = {backends: [
       {backend: backend1ctr},
       {backend: backend2ctr, preview: true, transition, skipDispatchOnTransition: true },
     ]};
@@ -340,7 +340,7 @@ describe('MultiBackend class', () => {
     });
 
     test('switches backend and does not re-call event handlers if skipDispatchOnTransition', () => {
-      const backend = createBackend(_defaultPipelineWithSkipDispatch);
+      const backend = createBackend(_pipelineWithSkipDispatch);
       expect(backend.current).toBe(0);
 
       const fakeEvent = {

--- a/packages/dnd-multi-backend/src/__tests__/MultiBackend_spec.js
+++ b/packages/dnd-multi-backend/src/__tests__/MultiBackend_spec.js
@@ -39,6 +39,7 @@ describe('PreviewList class', () => {
 
 describe('MultiBackend class', () => {
   let _defaultPipeline;
+  let _defaultPipelineWithSkipDispatch;
 
   beforeEach(() => {
     const newBackend = () => {
@@ -58,6 +59,10 @@ describe('MultiBackend class', () => {
     _defaultPipeline = {backends: [
       {backend: backend1ctr},
       {backend: backend2ctr, preview: true, transition},
+    ]};
+    _defaultPipelineWithSkipDispatch = {backends: [
+      {backend: backend1ctr},
+      {backend: backend2ctr, preview: true, transition, skipDispatchOnTransition: true },
     ]};
   });
 
@@ -327,6 +332,43 @@ describe('MultiBackend class', () => {
       const clonedEvent = fakeEvent.target.dispatchEvent.mock.calls[0][0];
       expect(clonedEvent.type).toBe('touchstart');
       expect(clonedEvent.cancelable).toBe(true);
+
+      expect(oldHandler).toHaveBeenCalledTimes(1);
+      expect(backend.callBackend).toHaveBeenCalledTimes(1);
+      expect(backend.callBackend).toBeCalledWith('connectDragSource', [2, 1, 4]);
+      expect(fakeNode.handler).toBe(fakeHandler);
+    });
+
+    test('switches backend and does not re-call event handlers if skipDispatchOnTransition', () => {
+      const backend = createBackend(_defaultPipelineWithSkipDispatch);
+      expect(backend.current).toBe(0);
+
+      const fakeEvent = {
+        constructor: TouchEvent.constructor,
+        type: 'touchstart',
+        cancelable: true,
+        bubbles: true,
+        touches: [Math.random()],
+        target: {dispatchEvent: jest.fn()},
+      };
+
+      const oldHandler = jest.fn();
+      const fakeNode = {func: 'connectDragSource', args: [2, 1, 4], handler: oldHandler};
+      const fakeHandler = {secret: Math.random()};
+      jest.spyOn(backend, 'callBackend').mockReturnValue(fakeHandler);
+      backend.nodes['123'] = fakeNode;
+
+      jest.spyOn(backend.backends[0].instance, 'teardown').mockImplementation(() => {});
+      jest.spyOn(backend.backends[1].instance, 'setup').mockImplementation(() => {});
+      expect(PreviewManager.backendChanged).not.toHaveBeenCalled();
+      backend.backendSwitcher(fakeEvent);
+      expect(PreviewManager.backendChanged).toHaveBeenCalledWith(backend);
+      expect(backend.backends[0].instance.teardown).toHaveBeenCalledTimes(1);
+      expect(backend.backends[1].instance.setup).toHaveBeenCalledTimes(1);
+
+      expect(backend.current).toBe(1);
+
+      expect(fakeEvent.target.dispatchEvent).not.toHaveBeenCalled();
 
       expect(oldHandler).toHaveBeenCalledTimes(1);
       expect(backend.callBackend).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
This library is awesome, and works really well for our use case of switching between the `HTML5Backend` and `TouchBackend`!

However, we're also using a separate library (`d3-zoom`) that attaches event listeners to the same mouse/touch events as the `MouseTransition` and `TouchTransition`.

The duplicate event dispatched in the `backendSwitcher` event handler was causing some weird behavior with our other event handlers.

Adding an option `skipDispatchOnTransition` for each backend to skip the extra event dispatch solved our problem! I added some documentation to the `react-dnd-multi-backend` package to explain how to use this new option, and a few warnings on why this _isn't_ the standard behavior (namely, the original event that triggered the transition won't be handled by the new backend).

This doesn't change any existing behavior, and is solely opt-in so this would not be considered a breaking change. Thanks for considering!