### PR TITLE
fix: round preview coordinates to avoid infinity updates

### DIFF
--- a/packages/react-dnd-preview/src/offsets.ts
+++ b/packages/react-dnd-preview/src/offsets.ts
@@ -16,8 +16,8 @@ export type Point = {
 
 const subtract = (a: Point, b: Point): Point => {
   return {
-    x: a.x - b.x,
-    y: a.y - b.y,
+    x: Math.round(a.x - b.x),
+    y: Math.round(a.y - b.y),
   }
 }
 


### PR DESCRIPTION
preview is throw error `Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops` when dragged object has float coordinates or dimensions

rounding solves this problem